### PR TITLE
Implement alloc-on-commit

### DIFF
--- a/fs/ext4/ext4_jbd2.h
+++ b/fs/ext4/ext4_jbd2.h
@@ -330,6 +330,15 @@ static inline handle_t *__ext4_journal_start(struct inode *inode,
 #define ext4_journal_stop(handle) \
 	__ext4_journal_stop(__func__, __LINE__, (handle))
 
+#ifdef CONFIG_EXT4_DJPLUS
+static inline void ext4djp_alloc_on_commit_or_stop(handle_t *handle,
+						   struct inode *inode)
+{
+	BUG_ON(!ext4_handle_valid(handle));
+	jdb2djp_journal_inode_precommit(handle, EXT4_I(inode)->jinode);
+}
+
+#endif
 #define ext4_journal_start_reserved(handle, type) \
 	__ext4_journal_start_reserved((handle), __LINE__, (type))
 

--- a/fs/ext4/ext4_jbd2.h
+++ b/fs/ext4/ext4_jbd2.h
@@ -335,7 +335,7 @@ static inline void ext4djp_alloc_on_commit_or_stop(handle_t *handle,
 						   struct inode *inode)
 {
 	BUG_ON(!ext4_handle_valid(handle));
-	jdb2djp_journal_inode_precommit(handle, EXT4_I(inode)->jinode);
+	jdb2djp_journal_inode_pre_commit(handle, EXT4_I(inode)->jinode);
 }
 
 #endif

--- a/fs/ext4/file.c
+++ b/fs/ext4/file.c
@@ -273,6 +273,7 @@ static ssize_t ext4_buffered_write_iter(struct kiocb *iocb,
 #ifdef CONFIG_EXT4_DJPLUS
 	handle_t *handle = NULL;
 	int needed_blocks;
+	unsigned int reserved_data_blocks;
 #endif
 	ssize_t ret;
 	struct inode *inode = file_inode(iocb->ki_filp);
@@ -289,6 +290,7 @@ static ssize_t ext4_buffered_write_iter(struct kiocb *iocb,
 	if (ext4_should_journal_data(inode)) {
 		// Temporal for needed blocks, block is insufficient do journal_extend();
 		needed_blocks = ext4djp_writepage_trans_blocks(inode, from->count);
+		reserved_data_blocks = EXT4_I(inode)->i_reserved_data_blocks;
 
 		handle = ext4_journal_start(inode, EXT4_HT_WRITE_PAGE, needed_blocks);
 		if (IS_ERR(handle)) {
@@ -303,8 +305,16 @@ static ssize_t ext4_buffered_write_iter(struct kiocb *iocb,
 	current->backing_dev_info = NULL;
 
 #ifdef CONFIG_EXT4_DJPLUS
-	if (ext4_should_journal_data(inode))
-		ext4djp_alloc_on_commit_or_stop(handle, inode);
+	if (ext4_should_journal_data(inode)) {
+		if (EXT4_I(inode)->i_reserved_data_blocks > reserved_data_blocks)
+			/* We did dealloc some block. */
+			ext4djp_alloc_on_commit_or_stop(handle, inode);
+		else {
+			/* We did not dealloc any block. */
+			BUG_ON(EXT4_I(inode)->i_reserved_data_blocks != reserved_data_blocks);
+			ext4_journal_stop(handle);
+		}
+	}
 #endif
 out:
 	inode_unlock(inode);

--- a/fs/ext4/file.c
+++ b/fs/ext4/file.c
@@ -304,7 +304,7 @@ static ssize_t ext4_buffered_write_iter(struct kiocb *iocb,
 
 #ifdef CONFIG_EXT4_DJPLUS
 	if (ext4_should_journal_data(inode))
-		ext4_journal_stop(handle);
+		ext4djp_alloc_on_commit_or_stop(handle, inode);
 #endif
 out:
 	inode_unlock(inode);

--- a/fs/ext4/inode.c
+++ b/fs/ext4/inode.c
@@ -1547,11 +1547,8 @@ static int ext4djp_journalled_write_end(struct file *file,
 	int size_changed = 0;
 	bool verity = ext4_verity_in_progress(inode);
 
-	if (buffer_delay(page_buffers(page))) {
-		// (junbong): We should stop this handle(started at ext4djp_write_begin)
-		// TODO: we may handle this case in ext4_da_write_end
+	if (buffer_delay(page_buffers(page)))
 		return ext4_da_write_end(file, mapping, pos, len, copied, page, fsdata);
-	}
 
 	trace_ext4djp_journalled_write_end(inode, pos, len, copied);
 	from = pos & (PAGE_SIZE - 1);

--- a/fs/ext4/super.c
+++ b/fs/ext4/super.c
@@ -529,7 +529,8 @@ static void ext4djp_alloc_on_commit_callback(journal_t *journal, transaction_t *
 		current->journal_info = jinode->i_handle;
 		jinode->i_handle = NULL;
 		write_unlock(&journal->j_state_lock);
-		ext4_alloc_da_blocks(jinode->i_vfs_inode);
+		if (EXT4_I(jinode->i_vfs_inode)->i_reserved_data_blocks)
+			filemap_fdatawrite(jinode->i_vfs_inode->i_mapping);
 		ext4_journal_stop(current->journal_info);
 		write_lock(&journal->j_state_lock);
 		list_del(&jinode->i_djp_list);

--- a/fs/jbd2/commit.c
+++ b/fs/jbd2/commit.c
@@ -488,10 +488,12 @@ void jbd2_journal_commit_transaction(journal_t *journal)
 
 	commit_transaction->t_state = T_SWITCH;
 
+#ifdef CONFIG_EXT4_DJPLUS
 	if (journal->j_pre_commit_callback)
 		journal->j_pre_commit_callback(journal, commit_transaction);
 
 	J_ASSERT(!atomic_read(&commit_transaction->t_updates));
+#endif
 	J_ASSERT (atomic_read(&commit_transaction->t_outstanding_credits) <=
 			journal->j_max_transaction_buffers);
 

--- a/fs/jbd2/commit.c
+++ b/fs/jbd2/commit.c
@@ -488,6 +488,10 @@ void jbd2_journal_commit_transaction(journal_t *journal)
 
 	commit_transaction->t_state = T_SWITCH;
 
+	if (journal->j_pre_commit_callback)
+		journal->j_pre_commit_callback(journal, commit_transaction);
+
+	J_ASSERT(!atomic_read(&commit_transaction->t_updates));
 	J_ASSERT (atomic_read(&commit_transaction->t_outstanding_credits) <=
 			journal->j_max_transaction_buffers);
 

--- a/fs/jbd2/journal.c
+++ b/fs/jbd2/journal.c
@@ -3042,7 +3042,9 @@ void jbd2_journal_init_jbd_inode(struct jbd2_inode *jinode, struct inode *inode)
 	jinode->i_flags = 0;
 	jinode->i_dirty_start = 0;
 	jinode->i_dirty_end = 0;
+	jinode->i_handle = NULL;
 	INIT_LIST_HEAD(&jinode->i_list);
+	INIT_LIST_HEAD(&jinode->i_djp_list);
 }
 
 /*

--- a/fs/jbd2/transaction.c
+++ b/fs/jbd2/transaction.c
@@ -2754,7 +2754,7 @@ int jbd2_journal_inode_ranged_wait(handle_t *handle, struct jbd2_inode *jinode,
 			start_byte, start_byte + length - 1);
 }
 
-int jdb2djp_journal_inode_precommit(handle_t *handle, struct jbd2_inode *jinode)
+int jdb2djp_journal_inode_pre_commit(handle_t *handle, struct jbd2_inode *jinode)
 {
 	transaction_t *transaction = handle->h_transaction;
 	journal_t *journal = transaction->t_journal;

--- a/include/linux/jbd2.h
+++ b/include/linux/jbd2.h
@@ -1593,7 +1593,7 @@ extern int	   jbd2_journal_inode_ranged_write(handle_t *handle,
 extern int	   jbd2_journal_inode_ranged_wait(handle_t *handle,
 			struct jbd2_inode *inode, loff_t start_byte,
 			loff_t length);
-extern int	   jdb2djp_journal_inode_precommit(
+extern int	   jdb2djp_journal_inode_pre_commit(
 			handle_t *handle, struct jbd2_inode *jinode);
 extern int	   jbd2_journal_submit_inode_data_buffers(
 			struct jbd2_inode *jinode);


### PR DESCRIPTION
# 변화사항
Write 에서 dealloc 이 발생한 경우, handle 을 그냥 stop 하지 않고 현재 running tx 에 그 inode 와 handle 을 등록합니다. 이후 commit 시점에 등록된 inode 들을 돌면서 dealloc 된 block 들을 할당합니다.

# 고민포인트들
- dealloc 리스트 관리를 위해 가장 큰 락(journal->j_state_lock)을 잡고하는데 더 잘할 수 없을지
- 현재는 등록할 때에 inode 를 등록하고 commit 시에 파일 전체 범위에 대해 writepages 를 부르도록 되어있음. 실제 write 가 발생한 영역(이상적으로는 dealloc 이 발생한 영역들)만 writepages 하도록 해야할수 있음
- writepages 시에 WB_SYNC_ALL 로 부르고있는데, 이게 충분한건지(이후 PREFLUSH 만으로 해당 페이지들의 write 를 보장할 수 있는지)